### PR TITLE
Fix: Added order param for bump and cancellation errors

### DIFF
--- a/helpers/order_helpers.rb
+++ b/helpers/order_helpers.rb
@@ -49,11 +49,11 @@ module Sinatra
       halt 413, error_object("Bid too low", "Per byte bid cannot be below #{MIN_PER_BYTE_BID} millisatoshis per byte. The minimum bid for this message is #{min_bid} millisatoshis.", ERROR::CODES[:BID_TOO_SMALL])
     end
     
-    def order_bump_error
+    def order_bump_error(order)
       halt 400, error_object("Cannot bump order", "Order already #{order.status}", ERROR::CODES[:ORDER_BUMP_ERROR])
     end
     
-    def order_cancellation_error
+    def order_cancellation_error(order)
       halt 400, error_object("Cannot cancel order", "Order already #{order.status}", ERROR::CODES[:ORDER_CANCELLATION_ERROR])
     end
 

--- a/main.rb
+++ b/main.rb
@@ -165,7 +165,7 @@ post '/order/:uuid/bump' do
   
   order = get_and_authenticate_order
   unless order.bump
-    order_bump_error
+    order_bump_error(order)
   end
   
   invoice = new_invoice(order, bid_increase)
@@ -189,7 +189,7 @@ delete '/order/:uuid' do
 
   order = get_and_authenticate_order
   unless order.cancel!
-    order_cancellation_error
+    order_cancellation_error(order)
   end
 
   {:message => "order cancelled"}.to_json


### PR DESCRIPTION
An exception was being thrown when a cancelled order was cancelled again or bumped.
This is what I was receiving:
![image](https://user-images.githubusercontent.com/1867877/55959188-322ef780-5c62-11e9-945f-4c41124e4fc7.png)

After the change, the response is as expected:
```
{
    "message": "Cannot bump order",
    "errors": [
        {
            "title": "Cannot bump order",
            "detail": "Order already cancelled",
            "code": 119
        }
    ]
}
```